### PR TITLE
Feature/ New column type: ParserStatusColumn

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Available cell types:
 - FloatColumn
 - BooleanColumn (will recognize ['yes', 'y', '+', '1', 'true'] as True, ['no', 'n', '-', '0', 'false'] as False)
 - ModelColumn (queryset should be declared, lookup_arg by default = 'pk', but can be changed. Returns model (one and only one!) responding by lookup)
+- ParserStatusColumn (use this field to recognize rows, not ready to be parsed; ready_status should be declared)
 
 In newly created parser:
 - Override method row(values) to process result of row-parsing

--- a/telega_megaimport/columns.py
+++ b/telega_megaimport/columns.py
@@ -177,3 +177,26 @@ class ModelColumn(BaseColumn):
             return error
         else:
             return None
+
+
+class ParserStatusColumn(BaseColumn):
+    """
+    Use for specifying data about parsing or skipping entire row
+    """
+    def __init__(self, ready_status=None, *args, **kwargs):
+        self.ready_status = ready_status
+        if ready_status is None:
+            raise ValueError('Ready status value is required!')
+        super(ParserStatusColumn, self).__init__(*args, **kwargs)
+
+    def normalize(self, value):
+        return value != self.ready_status
+
+    def validate(self, value):
+        error = super(ParserStatusColumn, self).validate(value) or []
+        if not isinstance(value, basestring):
+            error += ['Cannot read data from cell']
+        if error:
+            return error
+        else:
+            return None

--- a/telega_megaimport/parser.py
+++ b/telega_megaimport/parser.py
@@ -4,7 +4,7 @@ import django
 import os.path
 
 from optparse import make_option
-from columns import BaseColumn, EmptyColumn
+from columns import BaseColumn, EmptyColumn, ParserStatusColumn
 from collections import OrderedDict
 from xlrd import open_workbook
 from django.core.management import BaseCommand, CommandError
@@ -228,7 +228,8 @@ class BaseParser(with_metaclass(ParserMetaclass, BaseCommand)):
                     row_errors.append({coordinates: errors})
                 continue
             value = option.normalize(value)
-
+            if isinstance(option, ParserStatusColumn) and value:
+                return None
             try:
                 handler = getattr(self, '{}_handler'.format(option.title))
                 value = handler(value)

--- a/telega_megaimport/tests/models.py
+++ b/telega_megaimport/tests/models.py
@@ -13,4 +13,5 @@ class TestModel(models.Model):
 
 
 class BasicModel(TestModel):
-	text = models.CharField(max_length=100)
+    text = models.CharField(max_length=100)
+

--- a/telega_megaimport/tests/test_columns.py
+++ b/telega_megaimport/tests/test_columns.py
@@ -45,6 +45,7 @@ class EmptyColumnTest(TestCase):
     def test_validate(self):
         self.assertEqual(self.cell.validate('test'), None)
 
+
 class StringColumnTest(TestCase):
     def setUp(self):
         self.cell = columns.StringColumn(required=False)
@@ -85,6 +86,7 @@ class BooleanColumnTest(TestCase):
         self.assertEqual(self.cell.validate('test'), ['Value cannot be parsed as boolean'])
         self.assertEqual(self.cell.validate('+'), None)
 
+
 class FloatColumnTest(TestCase):
     def setUp(self):
         self.cell = columns.FloatColumn()
@@ -96,6 +98,7 @@ class FloatColumnTest(TestCase):
     def test_validate(self):
         self.assertEqual(self.cell.validate('111.111'), None)
         self.assertEqual(self.cell.validate('ttt'), ['Not convertable to float'])
+
 
 class ModelColumnTest(TestCase):
     def setUp(self):
@@ -120,3 +123,24 @@ class ModelColumnTest(TestCase):
     def test_validate(self):
         self.assertEqual(self.cell.validate(self.model_1.pk), self.model_1)
         self.assertEqual(self.cell.validate(101010101), ['Object not found'])
+
+
+class ParserStatusColumnTest(TestCase):
+    def setUp(self):
+        self.cell = columns.ParserStatusColumn(ready_status='ready')
+
+    def test_misdeclaration(self):
+        error = None
+        try:
+            columns.ParserStatusColumn()
+        except BaseException, e:
+            error = e
+        self.assertIsInstance(error, ValueError)
+
+    def test_normalize(self):
+        self.assertEqual(self.cell.normalize('ready'), False)
+        self.assertEqual(self.cell.normalize('ttt'), True)
+
+    def test_validate(self):
+        self.assertEqual(self.cell.validate('ready'), None)
+        self.assertEqual(self.cell.validate(11), ['Cannot read data from cell'])


### PR DESCRIPTION
ParserStatusColumn: use this column for status-check, defining, if
whole row should or should not be parsed. Argument 'ready_status'
must be declared.

Example:
status = ParseStatusColumn(ready_status='ready')

Parser will skip any row with it's value for status field != 'ready'
